### PR TITLE
opt: KVO keep wrapped value and EventObservable do not keep wrapped v…

### DIFF
--- a/Sources/ExtSwift/Foundation/KVO.swift
+++ b/Sources/ExtSwift/Foundation/KVO.swift
@@ -41,13 +41,13 @@ public class KVO<KVOType> {
     
     private var keepEventState: Bool
     
-    fileprivate init(wrappedValue: KVOType, keepEventState: Bool = false) {
+    fileprivate init(wrappedValue: KVOType, keepEventState: Bool = true) {
         self.wrappedValue = wrappedValue
         self.keepEventState = keepEventState
     }
     
     public convenience init(wrappedValue: KVOType) {
-        self.init(wrappedValue: wrappedValue, keepEventState: false)
+        self.init(wrappedValue: wrappedValue, keepEventState: true)
     }
     
     // MARK: observers
@@ -110,6 +110,10 @@ public final class EventObservable<KVOType>: KVO<KVOType> {
     
     public override init(wrappedValue: KVOType, keepEventState: Bool = false) {
         super.init(wrappedValue: wrappedValue, keepEventState: keepEventState)
+    }
+    
+    public convenience init(wrappedValue: KVOType) {
+        self.init(wrappedValue: wrappedValue, keepEventState: false)
     }
     
     @discardableResult


### PR DESCRIPTION
When use KVO for property, it may be nessary to keep the new value. 
On the other hand, the event observer override the convenience init method which can keep it the way it is.